### PR TITLE
Refactor max_seq_len from Tokenizer into TokenizedDataset

### DIFF
--- a/HOWTO.md
+++ b/HOWTO.md
@@ -70,8 +70,7 @@ Tokenizers (refer to `aria.tokenizer`) convert MidiDict objects into sequences o
 ```python
 # Loading Debussy's arabesque into a MidiDict and then tokenizing it
 MIDI_PATH = "./tests/test_data/arabesque.mid"
-midi = mido.MidiFile(MIDI_PATH)
-midi_dict = MidiDict.from_midi(midi)
+midi_dict = MidiDict.from_midi(MIDI_PATH)
 tokenizer = aria.tokenizer.TokenizerLazy()
 tokenized_seq = tokenizer.tokenize_midi_dict(midi_dict)
 print(tokenized_seq)
@@ -83,7 +82,7 @@ augmented_tokenized_seq = pitch_aug_fn(tokenized_seq)
 print(augmented_tokenized_seq)
 midi_dict = tokenizer.detokenize_midi_dict(augmented_tokenized_seq)
 midi = midi_dict.to_midi()
-midi.save('arabesque')
+midi.save('arabesque.mid')
 ```
 
 As we need rapid access to tokenized sequences during training, we use the class `aria.data.datasets.TokenizedDataset` to organize them into a dataset. This class implements the `torch.utils.data.Dataset` interface and can therefore be used with the PyTorch DataLoader class. There are a few important things to note about how TokenizedDataset works:
@@ -100,10 +99,11 @@ mididict_dataset = datasets.MidiDataset.build(
     dir="tests/test_data",
     recur=True,
 )
-tokenizer = tokenizer.TokenizerLazy(max_seq_len=512, return_tensors=True)
+tokenizer = tokenizer.TokenizerLazy(return_tensors=True)
 tokenized_dataset = datasets.TokenizedDataset.build(
     tokenizer=tokenizer,
     save_path="tokenized_dataset.jsonl",
+    max_seq_len=512,
     midi_dataset=mididict_dataset,
 )
 
@@ -114,18 +114,20 @@ datasets.MidiDataset.build_to_file(
     save_path="mididict_dataset.jsonl",
     recur=True,
 )
-tokenizer = tokenizer.TokenizerLazy(max_seq_len=512, return_tensors=True)
+tokenizer = tokenizer.TokenizerLazy(return_tensors=True)
 tokenized_dataset = datasets.TokenizedDataset.build(
     tokenizer=tokenizer,
     save_path="tokenized_dataset.jsonl",
+    max_seq_len=512,
     midi_dataset_path="mididict_dataset.jsonl",
 )
 
 # A short demonstration of how you might use TokenizerLazy during training
-tokenizer = tokenizer.TokenizerLazy(max_seq_len=512, return_tensors=True)
+tokenizer = tokenizer.TokenizerLazy(return_tensors=True)
 tokenized_dataset = datasets.TokenizedDataset.build(
     tokenizer=tokenizer,
     save_path="tokenized_dataset.jsonl",
+    max_seq_len=512, 
     midi_dataset_path="mididict_dataset.jsonl",
 )
 tokenized_dataset.set_transform(

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -35,7 +35,7 @@ As it stands, the basic functionality of the repository is implemented and teste
 
   We could investigate the possibility of adding Classical Archives' [MIDI collection](https://www.classicalarchives.com/midi.html) to the pre-training data.
   
-* [ ] **Refactor max_seq_len out of the Tokenizer class**
+* [x] **Refactor max_seq_len out of the Tokenizer class**
 
   This change may have adverse effects on other parts of the codebase, so it should be approached with caution. `max_seq_len` should be saved separately in the creation configuration for `TokenizedDataset`, similar to how padding and stride length are handled.
 * [ ] **Improve the striding mechanism in TokenizedDataset.build**

--- a/aria/data/midi.py
+++ b/aria/data/midi.py
@@ -134,8 +134,9 @@ class MidiDict:
         return cls(**msg_dict)
 
     @classmethod
-    def from_midi(cls, mid: mido.MidiFile):
-        """Inplace version of midi_to_dict."""
+    def from_midi(cls, mid_path: str):
+        """Loads a MIDI file and returns the coresponding MidiDict."""
+        mid = mido.MidiFile(mid_path)
         return cls(**midi_to_dict(mid))
 
     # TODO:

--- a/aria/tokenizer/tokenizer.py
+++ b/aria/tokenizer/tokenizer.py
@@ -14,25 +14,21 @@ from aria.config import load_config
 
 # TODO:
 # - Write tests
-# - Refactor max_seq_len out of the tokenizer class and into TokenizedDataset.
 
 
 class Tokenizer:
     """Abstract Tokenizer class for tokenizing midi_dict objects.
 
     Args:
-        max_seq_len (int): Maximum sequence length supported by tokenizer.
         return_tensors (bool, optional): If True, encode will return tensors.
             Defaults to False.
     """
 
     def __init__(
         self,
-        max_seq_len: int,
         return_tensors: bool = False,
     ):
         self.name = None
-        self.max_seq_len = max_seq_len
         self.return_tensors = return_tensors
 
         # These must be implemented in child class (abstract params)
@@ -95,10 +91,9 @@ class TokenizerLazy(Tokenizer):
 
     def __init__(
         self,
-        max_seq_len: int,
         return_tensors: bool = False,
     ):
-        super().__init__(max_seq_len, return_tensors)
+        super().__init__(return_tensors)
         self.config = load_config()["tokenizer"]["lazy"]
         self.name = "lazy"
 

--- a/run.py
+++ b/run.py
@@ -81,7 +81,6 @@ def sample(args):
     model = PretrainLM.load_from_checkpoint(ckpt_path).model
     max_seq_len = model.max_seq_len
     tokenizer = TokenizerLazy(
-        max_seq_len=max_seq_len,
         return_tensors=True,
     )
 
@@ -90,9 +89,7 @@ def sample(args):
     ), "Truncate length longer than maximum length supported by the model."
 
     # Load and format prompts
-    midi_dict = MidiDict.from_midi(
-        mid=mido.MidiFile(midi_path),
-    )
+    midi_dict = MidiDict.from_midi(mid_path=midi_path)
     prompt_seq = tokenizer.tokenize_midi_dict(midi_dict=midi_dict)
     prompt_seq = prompt_seq[:truncate_len]
     prompts = [prompt_seq for _ in range(num_variations)]
@@ -166,14 +163,16 @@ def data(args):
         ), "must provide a load_path or a directory containing midi"
 
         config = load_config()["data"]["dataset_gen_args"]
-        tokenizer = TokenizerLazy(max_seq_len=config["max_seq_len"])
+        # tokenizer = TokenizerLazy(max_seq_len=config["max_seq_len"])
+        tokenizer = TokenizerLazy()
         if args.load_path:
             TokenizedDataset.build(
                 tokenizer=tokenizer,
                 save_path=args.save_path,
                 midi_dataset_path=args.load_path,
-                padding=True,
+                max_seq_len=config["max_seq_len"],
                 stride_len=config["stride_len"],
+                padding=True,
                 overwrite=True,
             )
         elif args.dir:
@@ -188,8 +187,9 @@ def data(args):
                 tokenizer=tokenizer,
                 save_path=args.save_path,
                 midi_dataset_path=buffer_path,
-                padding=True,
+                max_seq_len=config["max_seq_len"],
                 stride_len=config["stride_len"],
+                padding=True,
                 overwrite=True,
             )
             os.remove(buffer_path)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -48,7 +48,7 @@ class TestMidiDataset(unittest.TestCase):
         self.assertEqual(type(dataset[0]), type(dataset_reloaded[0]))
 
     def test_build_to_file(self):
-        dataset = datasets.MidiDataset.build_to_file(
+        datasets.MidiDataset.build_to_file(
             dir="tests/test_data",
             save_path="tests/test_results/mididict_dataset_direct.jsonl",
             recur=True,
@@ -67,8 +67,8 @@ class TestMidiDataset(unittest.TestCase):
 class TestTokenizedDataset(unittest.TestCase):
     # Test building is working (on the file level)
     def test_build(self):
+        MAX_SEQ_LEN = 512
         tknzr = tokenizer.TokenizerLazy(
-            max_seq_len=512,
             return_tensors=False,
         )
         mididict_dataset = datasets.MidiDataset.build(
@@ -81,12 +81,14 @@ class TestTokenizedDataset(unittest.TestCase):
             tokenizer=tknzr,
             save_path="tests/test_results/dataset_buffer_1.jsonl",
             midi_dataset_path="tests/test_results/mididict_dataset.jsonl",
+            max_seq_len=MAX_SEQ_LEN,
             overwrite=True,
         )
         dataset_buffer_from_mdset = datasets.TokenizedDataset.build(
             tokenizer=tknzr,
             save_path="tests/test_results/dataset_buffer_2.jsonl",
             midi_dataset=mididict_dataset,
+            max_seq_len=MAX_SEQ_LEN,
             overwrite=True,
         )
 
@@ -105,8 +107,8 @@ class TestTokenizedDataset(unittest.TestCase):
         dataset_buffer_from_mdset.close()
 
     def test_mmap(self):
+        MAX_SEQ_LEN = 512
         tknzr = tokenizer.TokenizerLazy(
-            max_seq_len=512,
             return_tensors=False,
         )
         midi_dataset = datasets.MidiDataset.build(
@@ -117,6 +119,7 @@ class TestTokenizedDataset(unittest.TestCase):
             tokenizer=tknzr,
             save_path="tests/test_results/dataset_buffer.jsonl",
             midi_dataset=midi_dataset,
+            max_seq_len=MAX_SEQ_LEN,
             overwrite=True,
         )
 
@@ -130,8 +133,8 @@ class TestTokenizedDataset(unittest.TestCase):
         tokenized_dataset.close()
 
     def test_augmentation(self):
+        MAX_SEQ_LEN = 512
         tknzr = tokenizer.TokenizerLazy(
-            max_seq_len=512,
             return_tensors=False,
         )
         midi_dataset = datasets.MidiDataset.build(
@@ -142,6 +145,7 @@ class TestTokenizedDataset(unittest.TestCase):
             tokenizer=tknzr,
             save_path="tests/test_results/dataset_buffer.jsonl",
             midi_dataset=midi_dataset,
+            max_seq_len=MAX_SEQ_LEN,
             overwrite=True,
         )
         tokenized_dataset.set_transform(

--- a/tests/test_tokenizers.py
+++ b/tests/test_tokenizers.py
@@ -27,15 +27,14 @@ class TestLazyTokenizer(unittest.TestCase):
     # Add encode decode test
     def test_tokenize_detokenize_mididict(self):
         def tokenize_detokenize(file_name: str):
-            mid = mido.MidiFile(f"tests/test_data/{file_name}")
-            midi_dict = MidiDict.from_midi(mid)
+            mid_path = f"tests/test_data/{file_name}"
+            midi_dict = MidiDict.from_midi(mid_path=mid_path)
             tokenized_seq = tknzr.tokenize_midi_dict(midi_dict)
             detokenized_midi_dict = tknzr.detokenize_midi_dict(tokenized_seq)
             res = detokenized_midi_dict.to_midi()
             res.save(f"tests/test_results/{file_name}")
 
         tknzr = tokenizer.TokenizerLazy(
-            max_seq_len=512,
             return_tensors=False,
         )
 
@@ -48,7 +47,6 @@ class TestLazyTokenizer(unittest.TestCase):
 
     def test_aug(self):
         tknzr = tokenizer.TokenizerLazy(
-            max_seq_len=512,
             return_tensors=False,
         )
         seq = get_short_seq(tknzr)
@@ -71,7 +69,6 @@ class TestLazyTokenizer(unittest.TestCase):
 
     def test_encode_decode(self):
         tknzr = tokenizer.TokenizerLazy(
-            max_seq_len=512,
             return_tensors=True,
         )
         seq = get_short_seq(tknzr)
@@ -80,7 +77,6 @@ class TestLazyTokenizer(unittest.TestCase):
             self.assertEqual(x, y)
 
         tknzr = tokenizer.TokenizerLazy(
-            max_seq_len=512,
             return_tensors=False,
         )
         seq = get_short_seq(tknzr)

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -3,6 +3,12 @@ import logging
 import os
 
 from aria.training import pretrain
+from aria.tokenizer import TokenizerLazy
+from aria.data.midi import MidiDict
+from aria.data.datasets import MidiDataset, TokenizedDataset
+
+TRAIN_DATA_PATH = "tests/test_results/testoverfit_train_dataset.jsonl"
+VAL_DATA_PATH = "tests/test_results/testoverfit_val_dataset.jsonl"
 
 
 class TestTraining(unittest.TestCase):
@@ -10,20 +16,40 @@ class TestTraining(unittest.TestCase):
         pass
 
     def test_overfitting(self):
-        self.assertTrue(
-            os.path.isfile("data/train.jsonl"), "train data not found"
+        # Prepare datasets
+        train_mididict = MidiDict.from_midi("tests/test_data/beethoven.mid")
+        val_mididict = MidiDict.from_midi("tests/test_data/arabesque.mid")
+        train_midi_dataset = MidiDataset([train_mididict])
+        val_midi_dataset = MidiDataset([val_mididict])
+
+        tokenizer = TokenizerLazy(return_tensors=True)
+        TokenizedDataset.build(
+            tokenizer=tokenizer,
+            save_path=TRAIN_DATA_PATH,
+            midi_dataset=train_midi_dataset,
+            max_seq_len=256,
+            overwrite=True,
         )
-        self.assertTrue(os.path.isfile("data/val.jsonl"), "val data not found")
+        TokenizedDataset.build(
+            tokenizer=tokenizer,
+            save_path=VAL_DATA_PATH,
+            midi_dataset=val_midi_dataset,
+            max_seq_len=256,
+            overwrite=True,
+        )
+
+        self.assertTrue(os.path.isfile(TRAIN_DATA_PATH), "train data not found")
+        self.assertTrue(os.path.isfile(VAL_DATA_PATH), "val data not found")
 
         pretrain(
             model_name="test",
             tokenizer_name="lazy",
-            train_data_path="data/train.jsonl",
-            val_data_path="data/val.jsonl",
+            train_data_path=TRAIN_DATA_PATH,
+            val_data_path=VAL_DATA_PATH,
             workers=4,
             gpus=1,
             epochs=500,
-            batch_size=4,
+            batch_size=2,
             overfit=True,
         )
 


### PR DESCRIPTION
In this PR we make the following changes:

- Refactor so that tokenizers don't require a max_seq_len argument
- Change MidiDict.from_midi() so that it accepts a path instead of a mido.MidiFile object
- Add doc strings and make small corrections
- Update test_training.py & fix small bug in training.pretrain()
- Add asserts and logging statements