### PR TITLE
Implement tempo augmentation function for TokenizerLazy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,5 @@ cython_debug/
 tools/
 data/
 tests/test_results
+lightning_logs/
+.vscode/

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -13,7 +13,7 @@ As it stands, the basic functionality of the repository is implemented and teste
 * [ ] **Add chord mix-up data-augmentation function** 
 
   This (tokenized) data-augmentation function should randomly shuffle the order of notes that occur concurrently. For instance, `("piano", 60, 50), ("dur", 10), ("piano", 64, 50), ("dur", 20)` could be augmented to `("piano", 64, 50), ("dur", 20), ("piano", 60, 50), ("dur", 10)` as there is no wait token between the notes. See `aria.tokenizer.TokenizerLazy.export_pitch_aug()` for an example of how to implement data augmentation functions.
-* [ ] **Add speed data-augmentation function**
+* [x] **~~Add speed data-augmentation function~~**
 
   This data-augmentation function should change the speed of a tokenized sequence by some (float) factor. The main issue I foresee is accounting for the way that wait tokens are currently implemented. Depending on the `config.json`, the lazy tokenizer has a max wait token `("wait", t_max)`. Any 'wait' event longer than `t_max` is represented as a sequence of tokens. For instance, a wait of 2*t_max + 10ms would be `("wait", t_max), ("wait", t_max), ("wait", 10)`.
 * [x] **~~Fix encode/decode disparity bug~~**

--- a/aria/training.py
+++ b/aria/training.py
@@ -147,7 +147,11 @@ def pretrain(
 
     if overfit is False:
         train_dataset.set_transform(
-            [tokenizer.export_velocity_aug(2), tokenizer.export_pitch_aug(4)]
+            [
+                tokenizer.export_velocity_aug(2),
+                tokenizer.export_pitch_aug(4),
+                tokenizer.export_tempo_aug(0.15),
+            ]
         )
 
     train_dataloader = DataLoader(

--- a/tests/test_tokenizers.py
+++ b/tests/test_tokenizers.py
@@ -17,6 +17,12 @@ def get_short_seq(tknzr: tokenizer.TokenizerLazy):
         ("wait", tknzr._quantize_time(100)),
         ("drum", tknzr._quantize_time(50)),
         ("piano", 64, tknzr._quantize_velocity(70)),
+        ("dur", tknzr._quantize_time(1000000)),
+        ("wait", tknzr._quantize_time(1000000)),
+        ("wait", tknzr._quantize_time(1000000)),
+        ("wait", tknzr._quantize_time(1000000)),
+        ("wait", tknzr._quantize_time(100)),
+        ("piano", 65, tknzr._quantize_velocity(70)),
         ("dur", tknzr._quantize_time(100)),
         ("wait", tknzr._quantize_time(100)),
         "<E>",
@@ -52,6 +58,7 @@ class TestLazyTokenizer(unittest.TestCase):
         seq = get_short_seq(tknzr)
         pitch_aug_fn = tknzr.export_pitch_aug(aug_range=5)
         velocity_aug_fn = tknzr.export_velocity_aug(aug_steps_range=2)
+        tempo_aug_fn = tknzr.export_tempo_aug(tempo_aug_range=0.5)
 
         seq_pitch_augmented = pitch_aug_fn(get_short_seq(tknzr))
         logging.info(f"pitch_aug_fn:\n{seq} ->\n{seq_pitch_augmented}")
@@ -66,6 +73,9 @@ class TestLazyTokenizer(unittest.TestCase):
             seq_velocity_augmented[3][2] - seq[3][2],
             seq_velocity_augmented[7][2] - seq[7][2],
         )
+
+        seq_tempo_augmented = tempo_aug_fn(get_short_seq(tknzr))
+        logging.info(f"tempo_aug_fn:\n{seq} ->\n{seq_tempo_augmented}")
 
     def test_encode_decode(self):
         tknzr = tokenizer.TokenizerLazy(


### PR DESCRIPTION
In this PR we make the following changes:

- Implement the `export_tempo_aug` function in TokenizerLazy. This method returns a pure function which modifies the tempo of a tokenized sequence by a random amount. 
- Update the tokenizer tests to include `export_tempo_aug`.
- Update ROADMAP.md accordingly.
- Update .gitignore.