### PR TITLE
Add duplicate detection to MidiDataset build process

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,9 +19,9 @@ As it stands, the basic functionality of the repository is implemented and teste
 * [x] **~~Fix encode/decode disparity bug~~**
 
   There is a bug in MidiDict/TokenizerLazy that occasionally results in repeated notes being encoded incorrectly. This needs to be fixed before the main training can start.
-* [ ] **Add checksum pre-processing test**
+* [x] **~~Add checksum/hash pre-processing test~~**
 
-  Implement a pre-processing test which detects duplicate MIDI files by doing a sort of checksum on the MIDI file. I'm not quite sure how to implement this but it should not be too hard.
+  Implement a pre-processing test which detects duplicate MIDI files by doing a sort of checksum/hash on the MIDI file. I'm not quite sure how to implement this but it should not be too hard.
 * [x] **~~Add further pre-processing tests~~**
 
   Add further MidiDict pre-processing tests to improve dataset quality. Some ideas are checking for the frequency of note messages (an average of > 15 p/s or < 2 p/s is a bad sign). I'm open to any suggestions for MidiDict preprocessing tests. Properly cleaning pre-training datasets has a huge effect on model quality and robustness.

--- a/aria/data/midi.py
+++ b/aria/data/midi.py
@@ -1,5 +1,7 @@
 """Utils for data/MIDI processing."""
 
+import hashlib
+import json
 import mido
 
 from collections import defaultdict
@@ -140,6 +142,14 @@ class MidiDict:
         """Loads a MIDI file and returns the coresponding MidiDict."""
         mid = mido.MidiFile(mid_path)
         return cls(**midi_to_dict(mid))
+
+    def calculate_hash(self):
+        msg_dict_to_hash = self.get_msg_dict()
+        del msg_dict_to_hash["meta_msgs"]
+
+        return hashlib.md5(
+            json.dumps(msg_dict_to_hash, sort_keys=True).encode()
+        ).hexdigest()
 
     # TODO:
     # - Add remove drums (aka remove channel 9&16) pre-processing


### PR DESCRIPTION
This PR makes the following changes:

- Add a `calculate_hash` function to MidiDict.
- Use `calculate_hash` to automatically detect duplicates in `build_mididict_dataset`.