### PR TITLE
Change prefix token implementation - BREAKING

### DIFF
--- a/aria/data/datasets.py
+++ b/aria/data/datasets.py
@@ -389,33 +389,30 @@ class TokenizedDataset(torch.utils.data.Dataset):
         #   cut off or start early.
         # - Add docstring
         def _truncate_and_stride(_tokenized_seq: list):
-            present_instruments = []
+            prefix = []
 
             while _tokenized_seq:
                 tok = _tokenized_seq[0]
-                if isinstance(tok, str) and tok != tokenizer.bos_tok:
-                    present_instruments.append(_tokenized_seq.pop(0))
+                if tok != tokenizer.bos_tok and tok[0] == "prefix":
+                    prefix.append(_tokenized_seq.pop(0))
                 else:
                     break
 
             seq_len = len(_tokenized_seq)
-            prefix_len = len(present_instruments)
+            prefix_len = len(prefix)
 
             res = []
             idx = 0
             # No padding needed here
             while idx + max_seq_len - prefix_len < seq_len:
                 res.append(
-                    present_instruments
+                    prefix
                     + _tokenized_seq[idx : idx + max_seq_len - prefix_len]
                 )
                 idx += stride_len
 
             # Add the last sequence
-            _seq = (
-                present_instruments
-                + _tokenized_seq[idx : idx + max_seq_len - prefix_len]
-            )
+            _seq = prefix + _tokenized_seq[idx : idx + max_seq_len - prefix_len]
             if padding is True:
                 _seq += [tokenizer.pad_tok] * (max_seq_len - len(_seq))
             res.append(_seq)

--- a/aria/data/datasets.py
+++ b/aria/data/datasets.py
@@ -17,8 +17,6 @@ from aria.tokenizer import Tokenizer
 from aria.data.midi import MidiDict
 
 
-# TODO: Add proper docstring
-# - Add functionality for splitting the dataset into train-val split
 class MidiDataset:
     """Container for datasets of MidiDict objects.
 

--- a/aria/data/midi.py
+++ b/aria/data/midi.py
@@ -152,7 +152,7 @@ class MidiDict:
         ).hexdigest()
 
     # TODO:
-    # - Add remove drums (aka remove channel 9&16) pre-processing
+    # - Add remove drums (aka remove channel 9) pre-processing
     # - Add similar method for removing specific programs
     # - Decide whether this is necessary to have here in pre-precessing
     def remove_instruments(self, config: dict):
@@ -169,8 +169,8 @@ class MidiDict:
             if msg["data"] in programs_to_remove
         ]
 
-        # Remove drums (channel 9/16) from channels to remove
-        channels_to_remove = [i for i in channels_to_remove if i not in {9, 16}]
+        # Remove drums (channel 9) from channels to remove
+        channels_to_remove = [i for i in channels_to_remove if i != 9]
 
         # Remove unwanted messages all type by looping over msgs types. We need
         # to remove ticks_per_beat as this does not contain any messages.

--- a/aria/data/midi.py
+++ b/aria/data/midi.py
@@ -203,6 +203,8 @@ def _extract_track_data(track: mido.MidiTrack):
     for message in track:
         # Meta messages
         if message.is_meta is True:
+            # if message.type != "set_tempo":
+            #   print(message)
             if message.type == "text" or message.type == "copyright":
                 meta_msgs.append(
                     {

--- a/aria/tokenizer/tokenizer.py
+++ b/aria/tokenizer/tokenizer.py
@@ -88,6 +88,17 @@ class Tokenizer:
         return decoded_seq
 
 
+# TODO: ADD META TOKEN FUNCTIONALITY
+# - Refactor meta tokens so they are a triple ("meta", "val")
+#   this should make using tok_type stuff easier. This refactor should touch a
+#   lot of code so take care here.
+# - Add prefix class function to lazy tokenizer that calculates meta tokens.
+#   This prefix class should call various functions according to config.json.
+# - One function could be doing regex on the meta messages, looking for
+#   composer names. If one and only one composer name is found then it is added
+#   to the prefix before the instruments. We could specify the list of
+#   composers we are interested in in the config.json.
+# - By loading according to the config.json we could extend this easily.
 class TokenizerLazy(Tokenizer):
     """Lazy MidiDict Tokenizer"""
 
@@ -115,11 +126,14 @@ class TokenizerLazy(Tokenizer):
         ]
         self.max_velocity = self.velocity_quantizations[-1]
 
-        self.instrument_tokens = [
+        # _nd = no drum; _wd = with drum
+        self.instruments_nd = [
             k
             for k, v in self.config["ignore_instruments"].items()
             if v is False
-        ] + ["drums"]
+        ]
+        self.instruments_wd = self.instruments_nd + ["drum"]
+        self.prefix_tokens = [("prefix", x) for x in self.instruments_wd]
 
         # Build vocab
         self.special_tokens = [
@@ -136,7 +150,7 @@ class TokenizerLazy(Tokenizer):
 
         self.note_tokens = list(
             itertools.product(
-                self.instrument_tokens,
+                self.instruments_nd,
                 [i for i in range(128)],
                 self.velocity_quantizations,
             )
@@ -144,7 +158,7 @@ class TokenizerLazy(Tokenizer):
 
         self.vocab = (
             self.special_tokens
-            + self.instrument_tokens
+            + self.prefix_tokens
             + self.note_tokens
             + self.drum_tokens
             + self.dur_tokens
@@ -223,7 +237,7 @@ class TokenizerLazy(Tokenizer):
         else:
             return velocity_quantized
 
-    def _format(self, present_instruments: list, unformatted_seq: list):
+    def _format(self, prefix: list, unformatted_seq: list):
         # If unformatted_seq is longer than 150 tokens insert diminish tok
         idx = -100 + random.randint(-10, 10)
         if len(unformatted_seq) > 150:
@@ -232,12 +246,7 @@ class TokenizerLazy(Tokenizer):
             else:
                 unformatted_seq.insert(idx, self.dim_tok)
 
-        res = (
-            present_instruments
-            + [self.bos_tok]
-            + unformatted_seq
-            + [self.eos_tok]
-        )
+        res = prefix + [self.bos_tok] + unformatted_seq + [self.eos_tok]
 
         return res
 
@@ -263,11 +272,9 @@ class TokenizerLazy(Tokenizer):
                 channel_to_instrument[c] = "piano"
 
         # Add non-drums to present_instruments (prefix)
-        present_instruments = list(channel_to_instrument.values())
+        prefix = [("prefix", x) for x in set(channel_to_instrument.values())]
         if 9 in channels_used or 16 in channels_used:
-            present_instruments.append("drums")
-
-        present_instruments = list(set(present_instruments))
+            prefix.append(("prefix", "drum"))
 
         # NOTE: Any preceding silence is removed implicitly
         tokenized_seq = []
@@ -337,13 +344,12 @@ class TokenizerLazy(Tokenizer):
                     tokenized_seq.append(("wait", _wait_duration))
 
         return self._format(
-            present_instruments=present_instruments,
+            prefix=prefix,
             unformatted_seq=tokenized_seq,
         )
 
     def detokenize_midi_dict(self, tokenized_seq: list):
         instrument_programs = self.config["instrument_programs"]
-        instrument_names = instrument_programs.keys()
         TICKS_PER_BEAT = 480
         TEMPO = 500000
 
@@ -364,20 +370,32 @@ class TokenizerLazy(Tokenizer):
         instrument_to_channel = {"drum": 9}
 
         # Add non-drum instrument_msgs, breaks at first note token
+        channel_idx = 0
         for idx, tok in enumerate(tokenized_seq):
-            if tok in instrument_names:
-                instrument_msgs.append(
-                    {
-                        "type": "instrument",
-                        "data": instrument_programs[tok],
-                        "tick": 0,
-                        "channel": idx,
-                    }
-                )
-                assert tok not in instrument_to_channel.keys(), "Dupe"
-                instrument_to_channel[tok] = idx
+            # Make sure next available channel isn't drum channel
+            if channel_idx == 9 or channel_idx == 16:
+                channel_idx += 1
 
-            elif tok in self.special_tokens or tok == "drums":
+            if tok in self.special_tokens:
+                continue
+            # Non-drum instrument prefix tok
+            elif tok[0] == "prefix" and tok[1] in self.instruments_nd:
+                if tok[1] in instrument_to_channel.keys():
+                    logging.warning(f"Duplicate prefix {tok[1]}")
+                    continue
+                else:
+                    instrument_msgs.append(
+                        {
+                            "type": "instrument",
+                            "data": instrument_programs[tok[1]],
+                            "tick": 0,
+                            "channel": channel_idx,
+                        }
+                    )
+                    instrument_to_channel[tok[1]] = channel_idx
+                    channel_idx += 1
+            # Catches all other prefix tokens
+            elif tok[0] == "prefix":
                 continue
             else:
                 start = idx
@@ -391,15 +409,11 @@ class TokenizerLazy(Tokenizer):
         ):
             if curr_tok in self.special_tokens:
                 _curr_tok_type = "special"
-            elif isinstance(curr_tok, str):  # Present instrument prefix
-                _curr_tok_type = "prefix"
             else:
                 _curr_tok_type = curr_tok[0]
 
             if next_tok in self.special_tokens:
                 _next_tok_type = "special"
-            elif isinstance(next_tok, str):  # Present instrument prefix
-                _next_tok_type = "prefix"
             else:
                 _next_tok_type = next_tok[0]
 
@@ -440,7 +454,7 @@ class TokenizerLazy(Tokenizer):
                 )
 
             elif (
-                _curr_tok_type in self.instrument_tokens
+                _curr_tok_type in self.instruments_nd
                 and _next_tok_type == "dur"
             ):
                 duration = next_tok[1]

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -2,6 +2,7 @@ import unittest
 import os
 import logging
 import filecmp
+import random
 
 from aria import tokenizer
 from aria.data import datasets
@@ -77,6 +78,7 @@ class TestTokenizedDataset(unittest.TestCase):
         )
         mididict_dataset.save("tests/test_results/mididict_dataset.jsonl")
 
+        random.seed(42)
         dataset_buffer_from_file = datasets.TokenizedDataset.build(
             tokenizer=tknzr,
             save_path="tests/test_results/dataset_buffer_1.jsonl",
@@ -84,6 +86,7 @@ class TestTokenizedDataset(unittest.TestCase):
             max_seq_len=MAX_SEQ_LEN,
             overwrite=True,
         )
+        random.seed(42)
         dataset_buffer_from_mdset = datasets.TokenizedDataset.build(
             tokenizer=tknzr,
             save_path="tests/test_results/dataset_buffer_2.jsonl",

--- a/tests/test_tokenizers.py
+++ b/tests/test_tokenizers.py
@@ -9,8 +9,8 @@ from aria.data.midi import MidiDict
 
 def get_short_seq(tknzr: tokenizer.TokenizerLazy):
     return [
-        "piano",
-        "drums",
+        ("prefix", "piano"),
+        ("prefix", "drum"),
         "<S>",
         ("piano", 62, tknzr._quantize_velocity(50)),
         ("dur", tknzr._quantize_time(50)),


### PR DESCRIPTION
In this PR we make the following changes:

- Change the form that prefix tokens take. The token "piano" will now be ("prefix", "piano").
- Fix duplicate drum messages in TokenizerLazy
- Fix drum messages from being decoded over the incorrect channel (1 instead of 0).
- Make small improvements to detokenize_midi_dict in TokenizerLazy
- Fix a bug with dim_tok causing a data test to fail.

Note that as we are changing TokenizerLazy, it will no longer work with old model checkpoints.