### PR TITLE
Fix striding in TokenizedDataset

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -38,7 +38,7 @@ As it stands, the basic functionality of the repository is implemented and teste
 * [x] **~~Refactor max_seq_len out of the Tokenizer class~~**
 
   This change may have adverse effects on other parts of the codebase, so it should be approached with caution. `max_seq_len` should be saved separately in the creation configuration for `TokenizedDataset`, similar to how padding and stride length are handled.
-* [ ] **Improve the striding mechanism in TokenizedDataset.build**
+* [x] **~~Improve the striding mechanism in TokenizedDataset.build~~**
 
   Currently, striding can result in sequences starting or ending in awkward places. For example, it is possible for a sequence to begin with a duration token. Ideally, the logic should be modified to prevent this.
 * [ ] **Cultivate fine-tuning datasets**

--- a/aria/data/datasets.py
+++ b/aria/data/datasets.py
@@ -406,6 +406,16 @@ class TokenizedDataset(torch.utils.data.Dataset):
                 )
                 idx += stride_len
 
+                # Checks that next start note will not be cutoff midway
+                while idx < seq_len:
+                    # Break loop when a non 'wait' or 'dur' is seen
+                    if _tokenized_seq[idx] in tokenizer.special_tokens:
+                        break
+                    elif _tokenized_seq[idx][0] in {"wait", "dur"}:
+                        idx += 1
+                    else:
+                        break
+
             # Add the last sequence
             _seq = prefix + _tokenized_seq[idx : idx + max_seq_len - prefix_len]
             if padding is True:

--- a/aria/tokenizer/tokenizer.py
+++ b/aria/tokenizer/tokenizer.py
@@ -32,18 +32,26 @@ class Tokenizer:
         self.name = None
         self.return_tensors = return_tensors
 
+        self.bos_tok = "<S>"
+        self.eos_tok = "<E>"
+        self.pad_tok = "<P>"
+        self.unk_tok = "<U>"
+        self.dim_tok = "<D>"
+
+        self.special_tokens = [
+            self.bos_tok,
+            self.eos_tok,
+            self.pad_tok,
+            self.unk_tok,
+            self.dim_tok,
+        ]
+
         # These must be implemented in child class (abstract params)
         self.config = {}
         self.tok_to_id = {}
         self.id_to_tok = {}
         self.vocab_size = -1
         self.pad_id = -1
-
-        self.bos_tok = "<S>"
-        self.eos_tok = "<E>"
-        self.pad_tok = "<P>"
-        self.unk_tok = "<U>"
-        self.dim_tok = "<D>"
 
     def tokenize_midi_dict(self, midi_dict: MidiDict):
         """Abstract method for tokenizing a MidiDict object into a sequence of
@@ -133,14 +141,6 @@ class TokenizerLazy(Tokenizer):
         ]
 
         # Build vocab
-        self.special_tokens = [
-            self.bos_tok,
-            self.eos_tok,
-            self.pad_tok,
-            self.unk_tok,
-            self.dim_tok,
-        ]
-
         self.wait_tokens = [("wait", i) for i in self.time_step_quantizations]
         self.dur_tokens = [("dur", i) for i in self.time_step_quantizations]
         self.drum_tokens = [("drum", i) for i in range(35, 82)]


### PR DESCRIPTION
In this PR we fix the striding mechanism in TokenizedDataset so that it doesn't cutoff notes midway through.