### PR TITLE
Fix unnecessary drum tracks in LazyTokenizer 

### DIFF
--- a/aria/data/datasets.py
+++ b/aria/data/datasets.py
@@ -16,6 +16,7 @@ from aria.tokenizer import Tokenizer
 from aria.data.midi import MidiDict, get_test_fn
 
 
+# TODO: Investigate why loads of drums tracks are appearing when drum is present
 class MidiDataset:
     """Container for datasets of MidiDict objects.
 


### PR DESCRIPTION
Fixed issue where unnecessary drum trucks were being added in `TokenizerLazy.detokenize_midi_dict`. Note that some MIDI visualization tools still display multiple drum tracks for some reason.