### PR TITLE
Fix tempo bug in get_duration_ms

### DIFF
--- a/aria/data/midi.py
+++ b/aria/data/midi.py
@@ -94,6 +94,16 @@ class MidiDict:
         self.ticks_per_beat = ticks_per_beat
         self.metadata = metadata
 
+        # Special case that temo_msg is empty, in this case we spoof the default
+        if not self.tempo_msgs:
+            tempo_msgs = [
+                {
+                    "type": "tempo",
+                    "data": 500000,
+                    "tick": 0,
+                }
+            ]
+
         # This combines the individual dictionaries into one
         self.program_to_instrument = (
             {i: "piano" for i in range(0, 7 + 1)}

--- a/aria/train.py
+++ b/aria/train.py
@@ -376,6 +376,7 @@ def train(
         epoch_writer.writerow([0, avg_train_loss, avg_val_loss])
 
     for epoch in range(1, epochs + 1):
+        # Sometimes the epoch.csv isn't written to until it is closed?
         avg_train_loss = train_loop(dataloader=train_dataloader, _epoch=epoch)
         avg_val_loss = val_loop(dataloader=val_dataloader, _epoch=epoch)
         epoch_writer.writerow([epoch, avg_train_loss, avg_val_loss])


### PR DESCRIPTION
Fixed a bug where MIDI files without tempo messages are not parsed correctly.