### PR TITLE
Fix unk_tok bug in mixup augmentation 

### DIFF
--- a/aria/train.py
+++ b/aria/train.py
@@ -166,10 +166,10 @@ def get_dataloaders(
     if apply_aug:
         train_dataset.set_transform(
             [
+                tokenizer.export_chord_mixup(),
                 tokenizer.export_velocity_aug(2),
                 tokenizer.export_pitch_aug(5),
                 tokenizer.export_tempo_aug(0.15),
-                tokenizer.export_chord_mixup(),
             ]
         )
 
@@ -249,7 +249,7 @@ def train(
 
         logger.info(
             f"{total_flops / 1e12} TF, "
-            f"{iters_per_second * total_flops / 1e12} TF/s"
+            f"{iters_per_second * total_flops / 1e12} TF/s (not warm)"
         )
 
     def make_checkpoint(_accelerator, _epoch: int, _step: int | None = None):

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -8,6 +8,9 @@ from aria import tokenizer
 from aria.data import datasets
 from aria.data.midi import MidiDict
 
+if not os.path.isdir("tests/test_results"):
+    os.makedirs("tests/test_results")
+
 
 def get_short_seq():
     return [

--- a/tests/test_tokenizers.py
+++ b/tests/test_tokenizers.py
@@ -7,8 +7,8 @@ from aria import tokenizer
 from aria.data.midi import MidiDict
 
 
-# TODO: Add test which reports timings for the different augmentation functions
-# on the Beethoven sonata with len 2k and 4k.
+if not os.path.isdir("tests/test_results"):
+    os.makedirs("tests/test_results")
 
 
 def get_short_seq(tknzr: tokenizer.TokenizerLazy):

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -13,6 +13,8 @@ from aria.data.datasets import MidiDataset, TokenizedDataset
 TRAIN_DATA_PATH = "tests/test_results/testpretrain_dataset_train.jsonl"
 VAL_DATA_PATH = "tests/test_results/testpretrain_dataset_val.jsonl"
 
+if not os.path.isdir("tests/test_results"):
+    os.makedirs("tests/test_results")
 
 # TODO:
 # Add test for testing that rotary embeddings are working correctly. I want to


### PR DESCRIPTION
Fix a bug that resulted from `chord_mixup` being applied to a note that had been augmented to `unk_tok` by `pitch_aug`.