### PR TITLE
MidiDataset optimizations

### DIFF
--- a/aria/data/datasets.py
+++ b/aria/data/datasets.py
@@ -52,14 +52,14 @@ class MidiDataset:
         entries (list[MidiDict]): MidiDict objects to be stored.
     """
 
-    def __init__(self, entries: list[MidiDict]):
+    def __init__(self, entries: list[MidiDict] | Iterable):
         self.entries = entries
 
     def __len__(self):
-        return len(self.entries)
+        return len(list(self.entries))
 
     def __getitem__(self, ind: int):
-        return self.entries[ind]
+        return list(self.entries)[ind]
 
     def __iter__(self):
         yield from self.entries
@@ -74,12 +74,12 @@ class MidiDataset:
     @classmethod
     def load(cls, load_path: str):
         """Loads dataset from JSON file."""
-        midi_dicts = []
-        with jsonlines.open(load_path) as reader:
-            for entry in reader:
-                midi_dicts.append(MidiDict.from_msg_dict(entry))
+        def _load():
+            with jsonlines.open(load_path) as reader:
+                for entry in reader:
+                    yield MidiDict.from_msg_dict(entry)
 
-        return cls(midi_dicts)
+        return cls(_load())
 
     @classmethod
     def split_from_file(

--- a/aria/data/datasets.py
+++ b/aria/data/datasets.py
@@ -77,14 +77,18 @@ class MidiDataset:
                 writer.write(midi_dict.get_msg_dict())
 
     @classmethod
-    def load(cls, load_path: str):
+    def load(cls, load_path: str, stream=True):
         """Loads dataset from JSON file."""
+
         def _load():
             with jsonlines.open(load_path) as reader:
                 for entry in reader:
                     yield MidiDict.from_msg_dict(entry)
 
-        return cls(_load())
+        if stream == False:
+            return cls(list(_load()))
+        else:
+            return cls(_load())
 
     @classmethod
     def split_from_file(
@@ -552,8 +556,13 @@ class TokenizedDataset(torch.utils.data.Dataset):
             oq = Queue()
 
             _num_proc = os.cpu_count()
-            workers = [Process(target=functools.partial(_worker, tokenizer=tokenizer), args=(iq, oq)) for _ in
-                       range(_num_proc)]
+            workers = [
+                Process(
+                    target=functools.partial(_worker, tokenizer=tokenizer),
+                    args=(iq, oq),
+                )
+                for _ in range(_num_proc)
+            ]
             for w in workers:
                 w.start()
 

--- a/aria/data/datasets.py
+++ b/aria/data/datasets.py
@@ -57,10 +57,14 @@ class MidiDataset:
         self.entries = entries
 
     def __len__(self):
-        return len(list(self.entries))
+        if not isinstance(self.entries, list):
+            self.entries = list(self.entries)
+        return len(self.entries)
 
     def __getitem__(self, ind: int):
-        return list(self.entries)[ind]
+        if not isinstance(self.entries, list):
+            self.entries = list(self.entries)
+        return self.entries[ind]
 
     def __iter__(self):
         yield from self.entries
@@ -564,11 +568,11 @@ class TokenizedDataset(torch.utils.data.Dataset):
 
             with tqdm.tqdm() as t:
                 while True:
-                    try:
-                        result = oq.get(timeout=1000)
+                    if not oq.empty():
+                        result = oq.get()
                         t.update(1)
                         yield result
-                    except oq.Empty:
+                    else:
                         if not any(proc.is_alive() for proc in workers):
                             break
 

--- a/aria/data/jsonl_zst.py
+++ b/aria/data/jsonl_zst.py
@@ -18,7 +18,7 @@ class Reader:
         self.path = path
 
     def __iter__(self):
-        with builtins.open(self.path, 'rb') as fh:
+        with builtins.open(self.path, "rb") as fh:
             cctx = zstandard.ZstdDecompressor()
             reader = io.BufferedReader(cctx.stream_reader(fh))
             yield from jsonlines.Reader(reader)
@@ -36,13 +36,13 @@ class Writer:
         self.path = path
 
     def __enter__(self):
-        self.fh = builtins.open(self.path, 'wb')
+        self.fh = builtins.open(self.path, "wb")
         self.cctx = zstandard.ZstdCompressor()
         self.compressor = self.cctx.stream_writer(self.fh)
         return self
 
     def write(self, obj):
-        self.compressor.write(json.dumps(obj).encode('UTF-8') + b'\n')
+        self.compressor.write(json.dumps(obj).encode("UTF-8") + b"\n")
 
     def __exit__(self, exc_type, exc_value, traceback):
         self.compressor.flush(zstandard.FLUSH_FRAME)
@@ -62,9 +62,9 @@ def open(path: str, mode: str = "r"):
     Returns:
         Reader or Writer: Reader if mode is 'r', Writer if mode is 'w'.
     """
-    if mode == 'r':
+    if mode == "r":
         yield Reader(path)
-    elif mode == 'w':
+    elif mode == "w":
         with Writer(path) as writer:
             yield writer
     else:

--- a/aria/data/jsonl_zst.py
+++ b/aria/data/jsonl_zst.py
@@ -1,0 +1,71 @@
+import builtins
+import contextlib
+import io
+import zstandard
+import jsonlines
+import json
+
+
+class Reader:
+    """Reader for the jsonl.zst format."""
+
+    def __init__(self, path: str):
+        """Initializes the reader.
+
+        Args:
+            path (str): Path to the file.
+        """
+        self.path = path
+
+    def __iter__(self):
+        with builtins.open(self.path, 'rb') as fh:
+            cctx = zstandard.ZstdDecompressor()
+            reader = io.BufferedReader(cctx.stream_reader(fh))
+            yield from jsonlines.Reader(reader)
+
+
+class Writer:
+    """Writer for the jsonl.zst format."""
+
+    def __init__(self, path: str):
+        """Initializes the writer.
+
+        Args:
+            path (str): Path to the file.
+        """
+        self.path = path
+
+    def __enter__(self):
+        self.fh = builtins.open(self.path, 'wb')
+        self.cctx = zstandard.ZstdCompressor()
+        self.compressor = self.cctx.stream_writer(self.fh)
+        return self
+
+    def write(self, obj):
+        self.compressor.write(json.dumps(obj).encode('UTF-8') + b'\n')
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.compressor.flush(zstandard.FLUSH_FRAME)
+        self.fh.flush()
+        self.compressor.close()
+        self.fh.close()
+
+
+@contextlib.contextmanager
+def open(path: str, mode: str = "r"):
+    """Read/Write a jsonl.zst file.
+
+    Args:
+        path (str): Path to the file.
+        mode (str): Mode to open the file in. Only 'r' and 'w' are supported.
+
+    Returns:
+        Reader or Writer: Reader if mode is 'r', Writer if mode is 'w'.
+    """
+    if mode == 'r':
+        yield Reader(path)
+    elif mode == 'w':
+        with Writer(path) as writer:
+            yield writer
+    else:
+        raise ValueError(f"Unsupported mode '{mode}'")

--- a/aria/data/midi.py
+++ b/aria/data/midi.py
@@ -314,9 +314,7 @@ def _extract_track_data(track: mido.MidiTrack):
                 if len(notes_to_close) > 0 and len(notes_to_keep) > 0:
                     # Note-on on the same tick but we already closed
                     # some previous notes -> it will continue, keep it.
-                    last_note_on[
-                        (message.note, message.channel)
-                    ] = notes_to_keep
+                    last_note_on[(message.note, message.channel)] = notes_to_keep
                 else:
                     # Remove the last note on for this instrument
                     del last_note_on[(message.note, message.channel)]
@@ -402,9 +400,7 @@ def dict_to_midi(mid_data: dict):
     }, "Invalid json/dict."
 
     ticks_per_beat = mid_data.pop("ticks_per_beat")
-    mid_data = {
-        k: v for k, v in mid_data.items() if k not in {"meta_msgs", "metadata"}
-    }
+    mid_data = {k: v for k, v in mid_data.items() if k not in {"meta_msgs", "metadata"}}
 
     # Add all messages (not ordered) to one track
     track = mido.MidiTrack()
@@ -413,9 +409,7 @@ def dict_to_midi(mid_data: dict):
         for msg in msg_list:
             if msg["type"] == "tempo":
                 track.append(
-                    mido.MetaMessage(
-                        "set_tempo", tempo=msg["data"], time=msg["tick"]
-                    )
+                    mido.MetaMessage("set_tempo", tempo=msg["data"], time=msg["tick"])
                 )
             elif msg["type"] == "pedal":
                 track.append(
@@ -565,9 +559,7 @@ def _match_composer(text: str, composer_name: str):
         return False
 
 
-def meta_composer_filename(
-    mid: mido.MidiFile, msg_data: dict, composer_names: list
-):
+def meta_composer_filename(mid: mido.MidiFile, msg_data: dict, composer_names: list):
     file_name = pathlib.Path(mid.filename).stem
     matched_names = set()
     for name in composer_names:
@@ -582,9 +574,7 @@ def meta_composer_filename(
         return {}
 
 
-def meta_composer_metamsg(
-    mid: mido.MidiFile, msg_data: dict, composer_names: list
-):
+def meta_composer_metamsg(mid: mido.MidiFile, msg_data: dict, composer_names: list):
     matched_names = set()
     for msg in msg_data["meta_msgs"]:
         for name in composer_names:
@@ -608,9 +598,7 @@ def get_metadata_fn(metadata_proc_name: str):
 
     fn = name_to_fn.get(metadata_proc_name, None)
     if fn is None:
-        logging.error(
-            f"Error finding metadata function for {metadata_proc_name}"
-        )
+        logging.error(f"Error finding metadata function for {metadata_proc_name}")
     else:
         return fn
 
@@ -657,6 +645,10 @@ def test_note_frequency(
         tempo_msgs=midi_dict.tempo_msgs,
         ticks_per_beat=midi_dict.ticks_per_beat,
     )
+
+    if total_duration_ms == 0:
+        return False, 0.0
+
     notes_per_second = (num_notes * 1e3) / total_duration_ms
 
     if notes_per_second < min_per_second or notes_per_second > max_per_second:
@@ -687,6 +679,10 @@ def test_note_frequency_per_instrument(
         tempo_msgs=midi_dict.tempo_msgs,
         ticks_per_beat=midi_dict.ticks_per_beat,
     )
+
+    if total_duration_ms == 0:
+        return False, 0.0
+
     notes_per_second = (num_notes * 1e3) / total_duration_ms
 
     note_freq_per_instrument = notes_per_second / num_instruments

--- a/aria/data/midi.py
+++ b/aria/data/midi.py
@@ -1,5 +1,5 @@
 """Utils for data/MIDI processing."""
-
+import functools
 import hashlib
 import json
 import re
@@ -114,8 +114,10 @@ class MidiDict:
                 }
             ]
 
+    @functools.cached_property
+    def program_to_instrument(self):
         # This combines the individual dictionaries into one
-        self.program_to_instrument = (
+        return (
             {i: "piano" for i in range(0, 7 + 1)}
             | {i: "chromatic" for i in range(8, 15 + 1)}
             | {i: "organ" for i in range(16, 23 + 1)}

--- a/aria/data/midi.py
+++ b/aria/data/midi.py
@@ -1,5 +1,4 @@
 """Utils for data/MIDI processing."""
-import functools
 import hashlib
 import json
 import re

--- a/aria/data/midi.py
+++ b/aria/data/midi.py
@@ -114,8 +114,9 @@ class MidiDict:
                 }
             ]
 
-    @functools.cached_property
-    def program_to_instrument(self):
+    @classmethod
+    @property
+    def program_to_instrument(cls):
         # This combines the individual dictionaries into one
         return (
             {i: "piano" for i in range(0, 7 + 1)}

--- a/aria/model/model.py
+++ b/aria/model/model.py
@@ -320,7 +320,7 @@ class Transformer(nn.Module):
 
                     return custom_forward
 
-                hidden_states = torch.utils.checkpoint.checkpoint(
+                hidden_states, _ = torch.utils.checkpoint.checkpoint(
                     create_custom_forward(layer),
                     hidden_states,
                     preserve_rng_state=True,

--- a/aria/model/model.py
+++ b/aria/model/model.py
@@ -22,6 +22,7 @@ class YaRNConfig:
         mscale_coeff (int): Temperature scaling factor t follows `a ln s + 1.0`,
             and the coefficient `a` is this `mscale_coeff` here.
     """
+
     beta_fast: int = 16
     beta_slow: int = 1
     scale: int = 1.0
@@ -43,7 +44,6 @@ class ModelConfig:
     def __post_init__(self):
         if self.yarn_config is not None and isinstance(self.yarn_config, dict):
             self.yarn_config = YaRNConfig(**self.yarn_config)
-
 
     def set_vocab_size(self, vocab_size: int):
         self.vocab_size = vocab_size

--- a/aria/run.py
+++ b/aria/run.py
@@ -124,6 +124,7 @@ def _parse_tokenized_dataset_args():
     argp.add_argument("load_path", help="path midi_dict dataset")
     argp.add_argument("save_path", help="path to save dataset")
     argp.add_argument("-s", help="also produce shuffled", action="store_true")
+    argp.add_argument("-l", help="max sequence length", type=int, default=2048)
 
     return argp.parse_args(sys.argv[2:])
 
@@ -131,15 +132,13 @@ def _parse_tokenized_dataset_args():
 def build_tokenized_dataset(args):
     from aria.tokenizer import TokenizerLazy
     from aria.data.datasets import TokenizedDataset
-    from aria.config import load_config
 
-    config = load_config()["data"]["dataset_gen_args"]
     tokenizer = TokenizerLazy()
     dataset = TokenizedDataset.build(
         tokenizer=tokenizer,
         save_path=args.save_path,
         midi_dataset_path=args.load_path,
-        max_seq_len=config["max_seq_len"],
+        max_seq_len=args.l,
         overwrite=True,
     )
     if args.s:

--- a/aria/run.py
+++ b/aria/run.py
@@ -124,7 +124,7 @@ def _parse_tokenized_dataset_args():
     argp.add_argument("load_path", help="path midi_dict dataset")
     argp.add_argument("save_path", help="path to save dataset")
     argp.add_argument("-s", help="also produce shuffled", action="store_true")
-    argp.add_argument("-l", help="max sequence length", type=int, default=2048)
+    argp.add_argument("-l", help="max sequence length", type=int)
 
     return argp.parse_args(sys.argv[2:])
 

--- a/config/config.json
+++ b/config/config.json
@@ -70,9 +70,6 @@
                     "composer_names": ["bach", "beethoven", "mozart", "chopin", "rachmaninoff", "liszt", "debussy", "schubert", "brahms", "ravel", "satie", "scarlatti"]
                 }
             }
-        },
-        "dataset_gen_args": {
-            "max_seq_len": 2048
         }
     },
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -5,6 +5,7 @@ import logging
 from aria import tokenizer
 from aria.data import datasets
 from aria.data.midi import MidiDict
+from aria.data import jsonl_zst
 
 if not os.path.isdir("tests/test_results"):
     os.makedirs("tests/test_results")
@@ -243,6 +244,23 @@ class TestTokenizedDataset(unittest.TestCase):
         )
 
         tokenized_dataset.close()
+
+
+class TestReaderWriter(unittest.TestCase):
+    def test_jsonl_zst(self):
+        data = [{"a": i, "b": i+1} for i in range(0, 100, 4)]
+        filename = "tests/test_results/test.jsonl.zst"
+        # if test.jsonl.zst exists, delete it
+        if os.path.isfile(filename):
+            os.remove(filename)
+        with jsonl_zst.open(filename, "w") as f:
+            for d in data:
+                f.write(d)
+        with jsonl_zst.open(filename, "r") as f:
+            for d, d2 in zip(data, f):
+                self.assertEqual(d, d2)
+        # Remove the file
+        os.remove(filename)
 
 
 if __name__ == "__main__":

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -248,7 +248,7 @@ class TestTokenizedDataset(unittest.TestCase):
 
 class TestReaderWriter(unittest.TestCase):
     def test_jsonl_zst(self):
-        data = [{"a": i, "b": i+1} for i in range(0, 100, 4)]
+        data = [{"a": i, "b": i + 1} for i in range(0, 100, 4)]
         filename = "tests/test_results/test.jsonl.zst"
         # if test.jsonl.zst exists, delete it
         if os.path.isfile(filename):


### PR DESCRIPTION
- [x] can initialize with an iterator and only expand when necessary (__len__ or random access).
- [x] reduce a little memory/initialization overhead by changing `program_to_instrument` dict into a getter function (we are starting to have >100k MidiDataset and could have more in the future) 

note: I thought we might hide some latency by doing json.decode async during tokenizer encoding. But doesn't feel like helping much....... However, I have a separate script to build a static huggingface tokenized dataset and it seems to help.
update: Now it's slightly faster by using persistent workers reading queues in `while True` loops, instead of process pool. The processes are spun up only once and therefore tokenizers are pickled only once